### PR TITLE
Fix samtools sort bug

### DIFF
--- a/Scripts/tepid-map
+++ b/Scripts/tepid-map
@@ -69,7 +69,7 @@ map () {
   rm "${fname}.split.sam"
 
   echo "Sorting alignment"
-  samtools sort -@ $proc "${fname}_unsort.bam" "${fname}"
+  samtools sort -@ $proc "${fname}_unsort.bam" > "${fname}"
   rm "${fname}_unsort.bam"
 
   echo "Indexing alignment"


### PR DESCRIPTION
The newer versions of samtools requires a redirect sign '>' or the argument '-o' for the output file. The current pipeline generates the error "[bam_sort] Use -T PREFIX / -o FILE to specify temporary and final output files". I added the redirection sign '>' to solve the problem