### PR TITLE
fix bug remove_temp function

### DIFF
--- a/tepid/tepid.py
+++ b/tepid/tepid.py
@@ -1126,7 +1126,7 @@ def discover_pe(options):
 def remove_temp(options):
     if options.keep is False:
         temp = glob('./*.temp')
-        mytempfiles = [x for x in temp if x.startswith(options.prefix)]
+        mytempfiles = [x for x in temp if x.startswith("./"+options.prefix)]
         for i in mytempfiles:
             os.remove(i)
         os.remove(options.prefix + 'disc_sorted.bam')


### PR DESCRIPTION
This function was not working with temporary files staying in directory after running tepid-discover. The matching pattern was not working as the file names start with "./" in the list temp.  Now it works by adding the string "./" in the search pattern of startswith()